### PR TITLE
fetch capsules near user with radius, filters, and pagination

### DIFF
--- a/src/controllers/secretDrop/secretDrop.controller.ts
+++ b/src/controllers/secretDrop/secretDrop.controller.ts
@@ -2,13 +2,13 @@ import { Request, Response } from 'express';
 import {
   SecretDropCapsuleModel,
   SecretDropSchema,
-} from '../models/secretDropCapsule';
+} from '../../models/secretDropCapsule';
 import crypto from 'crypto';
 
 const HASH_LENGTH = 12;
 const PEPPER = process.env.SECRET_HASH_PEPPER!;
 
-export function generateUniqueHash(capsule): string {
+export function generateUniqueHash(capsule: { _id: string; createdAt: { toISOString: () => string; }; }): string {
   const input = `${capsule._id}${capsule.createdAt.toISOString()}${PEPPER}`;
 
   return crypto
@@ -35,7 +35,7 @@ export const createSecretDropCapsule = async (req: Request, res: Response) => {
     res.status(201).json({
       id: capsule._id,
       message: 'Capsule created successfully',
-      hash: generateUniqueHash(capsule),
+      hash: generateUniqueHash({ _id: String(capsule._id), createdAt: capsule.createdAt }),
     });
   } catch (error) {
     res.status(400).json({
@@ -53,7 +53,7 @@ export const getCapsule = async (req: Request, res: Response) => {
 
     if (!capsule) return res.status(404).json({ error: 'Capsule not found' });
     res.json(capsule);
-  } catch (error) {
+  } catch {
     res.status(500).json({ error: 'Server error' });
   }
 };
@@ -86,7 +86,7 @@ export const deleteCapsule = async (req: Request, res: Response) => {
     if (!capsule) return res.status(404).json({ error: 'Capsule not found' });
 
     res.json({ success: true });
-  } catch (error) {
+  } catch {
     res.status(500).json({ error: 'Server error' });
   }
 };

--- a/src/models/Capsule.js
+++ b/src/models/Capsule.js
@@ -1,0 +1,24 @@
+import mongoose from 'mongoose';
+
+const capsuleSchema = new mongoose.Schema({
+  type:        { type: String, required: true },
+  preview:     { type: String, required: true },  
+  message:     { type: String },                  
+  timestamp:   { type: Date, default: Date.now },
+  location: {
+    type: {
+      type: String,
+      enum: ['Point'],
+      required: true,
+      default: 'Point'
+    },
+    coordinates: {
+      type: [Number], 
+      required: true
+    }
+  }
+});
+
+capsuleSchema.index({ location: '2dsphere' });
+
+export default mongoose.model('Capsule', capsuleSchema);

--- a/src/models/secretDropCapsule.ts
+++ b/src/models/secretDropCapsule.ts
@@ -1,0 +1,82 @@
+import mongoose, { Schema, Document } from 'mongoose';
+
+// Types for unlock conditions and visibility
+const TimeWindowSchema = new Schema({
+  start: { type: Date },
+  end: { type: Date },
+}, { _id: false });
+
+const UnlockConditionsSchema = new Schema({
+  timeWindow: { type: TimeWindowSchema },
+}, { _id: false });
+
+const VisibilitySchema = new Schema({
+  public: { type: Boolean, default: true },
+}, { _id: false });
+
+// Capsule Document interface
+export interface SecretDropCapsuleDocument extends Document {
+  creatorId: string;
+  title: string;
+  message: string;
+  location: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  isActive: boolean;
+  visibility: {
+    public: boolean;
+  };
+  unlockConditions?: {
+    timeWindow?: {
+      start?: Date;
+      end?: Date;
+    };
+  };
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+// Main Capsule Schema
+const SecretDropCapsuleSchema = new Schema<SecretDropCapsuleDocument>(
+  {
+    creatorId: { type: String, required: true },
+    title: { type: String, required: true },
+    message: { type: String, required: true },
+
+    location: {
+      type: {
+        type: String,
+        enum: ['Point'],
+        required: true,
+      },
+      coordinates: {
+        type: [Number], // [longitude, latitude]
+        required: true,
+      },
+    },
+
+    isActive: { type: Boolean, default: true },
+
+    visibility: {
+      type: VisibilitySchema,
+      default: { public: true },
+    },
+
+    unlockConditions: {
+      type: UnlockConditionsSchema,
+      default: {},
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+// 2dsphere index for geospatial queries
+SecretDropCapsuleSchema.index({ location: '2dsphere' });
+
+export const SecretDropCapsuleModel = mongoose.model<SecretDropCapsuleDocument>(
+  'SecretDropCapsule',
+  SecretDropCapsuleSchema
+);

--- a/src/routes/capsules.js
+++ b/src/routes/capsules.js
@@ -1,0 +1,77 @@
+
+import express from 'express';
+const router  = express.Router();
+import Capsule from '../models/Capsule';
+
+router.get('/nearby', async (req, res, next) => {
+  try {
+    const {
+      lat,
+      lng,
+      radius = 500,
+      page = 1,
+      limit = 20,
+      type,
+      startTime,
+      endTime
+    } = req.query;
+
+    // Validate required params
+    if (!lat || !lng) {
+      return res.status(400).json({ error: 'lat and lng are required' });
+    }
+
+    // Build geo‐filter
+    const geoFilter = {
+      location: {
+        $nearSphere: {
+          $geometry: {
+            type: 'Point',
+            coordinates: [ parseFloat(lng), parseFloat(lat) ]
+          },
+          $maxDistance: parseInt(radius, 10)
+        }
+      }
+    };
+
+    // Build other filters
+    const otherFilters = {};
+    if (type) {
+      otherFilters.type = type;
+    }
+    if (startTime || endTime) {
+      otherFilters.timestamp = {};
+      if (startTime) otherFilters.timestamp.$gte = new Date(startTime);
+      if (endTime)   otherFilters.timestamp.$lte = new Date(endTime);
+    }
+
+    // Combine filters
+    const filter = { ...geoFilter, ...otherFilters };
+
+    // Pagination
+    const skip = (Math.max(parseInt(page, 10), 1) - 1) * parseInt(limit, 10);
+
+  const capsules = await Capsule
+      .find(filter)
+      .select('type preview timestamp location') 
+      .skip(skip)
+      .limit(parseInt(limit, 10));
+
+    
+    const total = await Capsule.countDocuments(filter);
+
+    res.json({
+      meta: {
+        page:   parseInt(page, 10),
+        limit:  parseInt(limit, 10),
+        total
+      },
+      data: capsules
+    });
+
+  } catch (err) {
+    next(err);
+  }
+});
+
+export default router;

--- a/src/utils/formatCapsuleForResponse.ts
+++ b/src/utils/formatCapsuleForResponse.ts
@@ -1,0 +1,36 @@
+interface Capsule {
+    _id: string;
+    title: string;
+    location: {
+      type: string;
+      coordinates: [number, number];
+    };
+    createdAt: Date;
+    visibility: {
+      public: boolean;
+    };
+    unlockConditions: { [key: string]: unknown };
+    message?: string;
+    [key: string]: unknown;
+  }
+  
+  /**
+   * 
+   * @param capsule 
+   * @param includeMessage 
+   */
+  export default function formatCapsuleForResponse(
+    capsule: Capsule,
+    includeMessage: boolean = true
+  ) {
+    return {
+      id: capsule._id.toString(),
+      title: capsule.title,
+      location: capsule.location,
+      createdAt: capsule.createdAt,
+      visibility: capsule.visibility,
+      unlockConditions: capsule.unlockConditions,
+      ...(includeMessage && { message: capsule.message }),
+    };
+  }
+  

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,0 +1,62 @@
+/**
+ * Formats a capsule document for API response
+ * @param {Object} capsule - The capsule document from MongoDB
+ * @param {Boolean} includeFullMessage - Whether to include the full message (true) or not (false)
+ * @returns {Object} Formatted capsule object
+ */
+export function formatCapsuleForResponse(capsule, includeFullMessage = false) {
+  // Base capsule info
+  const formattedCapsule = {
+    id: capsule._id.toString(),
+    title: capsule.title,
+    createdAt: capsule.createdAt,
+    location: {
+      type: capsule.location.type,
+      coordinates: capsule.location.coordinates,
+    },
+    creator: capsule.creator
+      ? {
+          id: capsule.creator.toString(),
+          // If you have a populated creator field, you could add more fields here
+        }
+      : null,
+    // Include access and visibility settings
+    visibility: {
+      public: capsule.visibility.public,
+      friends: capsule.visibility.friends || [],
+    },
+    // Include unlock conditions
+    unlockConditions: {
+      proximityRequired: capsule.unlockConditions?.proximityRequired || false,
+      proximityRadius: capsule.unlockConditions?.proximityRadius || 50,
+      timeWindow: capsule.unlockConditions?.timeWindow
+        ? {
+            start: capsule.unlockConditions.timeWindow.start,
+            end: capsule.unlockConditions.timeWindow.end,
+          }
+        : null,
+    },
+    // Include metadata
+    metadata: {
+      views: capsule.metadata?.views || 0,
+      unlocks: capsule.metadata?.unlocks || 0,
+      tags: capsule.metadata?.tags || [],
+    },
+  };
+
+  // Include the message based on the flag
+  if (includeFullMessage && capsule.message) {
+    formattedCapsule.message = capsule.message;
+  }
+
+  // Include media URLs if present
+  if (capsule.media && capsule.media.length > 0) {
+    formattedCapsule.media = capsule.media.map((item) => ({
+      type: item.type,
+      url: item.url,
+      thumbnail: item.thumbnail || null,
+    }));
+  }
+
+  return formattedCapsule;
+}


### PR DESCRIPTION
### Description:
Implemented the ability to fetch capsules near a user's location using MongoDB’s `$nearSphere`. This includes:

- 🌍 **Geospatial search** using `$nearSphere`
- 📏 **Dynamic radius** support (default to 500 meters)
- 🔄 **Pagination** using limit and skip
- 🔍 **Filter by capsule type** (e.g. public/private) and **creation time**
- 📦 **Optimized response** to return only capsule previews (e.g. id, title, location, type) without full message content

This feature will improve UX by enabling users to find relevant nearby capsules quickly and efficiently.

closes #131 