### PR TITLE
Feature: SecretDropUnlock Schema & Unlock History Endpoint

### DIFF
--- a/src/controllers/secretDrop/unlockedCapsules.controller.ts
+++ b/src/controllers/secretDrop/unlockedCapsules.controller.ts
@@ -1,0 +1,162 @@
+import { Request, Response } from 'express';
+const SecretDropUnlock = require('../../models/capsuleLab/secretDropUnlock');
+
+export const unlockedCapsules = async (req: Request, res: Response) => {
+  try {
+    const {
+      limit = 20,
+      skip = 0,
+      sortBy = 'recent', // 'recent' or 'oldest'
+    } = req.query;
+
+    // Parse pagination params
+    const parsedLimit = Math.min(Math.max(parseInt(limit), 1), 50); // Between 1 and 50
+    const parsedSkip = Math.max(parseInt(skip), 0); // Min 0
+
+    // Determine sort order
+    const sortOrder = sortBy === 'oldest' ? 1 : -1;
+
+    // Query for user's unlock history
+    const unlocks = await SecretDropUnlock.find({
+      userId: req.user._id,
+    })
+      .sort({ unlockTime: sortOrder })
+      .skip(parsedSkip)
+      .limit(parsedLimit)
+      .populate({
+        path: 'capsuleId',
+        select:
+          'message location hint creatorId unlockConditions visibility metadata',
+      })
+      .lean();
+
+    // Get total count for pagination
+    const totalCount = await SecretDropUnlock.countDocuments({
+      userId: req.user._id,
+    });
+
+    // Format the results
+    const formattedUnlocks = unlocks.map((unlock) => {
+      // Skip if the related capsule is not found (may have been deleted)
+      if (!unlock.capsuleId) {
+        return {
+          id: unlock._id,
+          unlockTime: unlock.unlockTime,
+          capsuleDeleted: true,
+        };
+      }
+
+      // Format capsule data
+      const capsule = unlock.capsuleId;
+
+      return {
+        id: unlock._id,
+        unlockTime: unlock.unlockTime,
+        distanceAtUnlock: unlock.distanceAtUnlock,
+        capsule: {
+          id: capsule._id,
+          message: capsule.message,
+          location: capsule.location,
+          hint: capsule.hint,
+          creatorId: capsule.creatorId,
+        },
+        reply: unlock.reply,
+        // Add whether user can still reply
+        canReply:
+          !unlock.reply?.content &&
+          new Date() - new Date(unlock.unlockTime) < 5 * 60 * 1000,
+        streakDay: unlock.streakDay,
+      };
+    });
+
+    // Remove any null entries (from deleted capsules)
+    const filteredUnlocks = formattedUnlocks.filter(
+      (unlock) => unlock !== null
+    );
+
+    return res.status(200).json({
+      success: true,
+      data: filteredUnlocks,
+      pagination: {
+        total: totalCount,
+        limit: parsedLimit,
+        skip: parsedSkip,
+        hasMore: totalCount > parsedSkip + parsedLimit,
+      },
+    });
+  } catch (error) {
+    console.error('Error fetching unlock history:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'An error occurred while fetching unlock history',
+      error: process.env.NODE_ENV === 'development' ? error.message : undefined,
+    });
+  }
+};
+
+export const unlockCapsule = async (req: Request, res: Response) => {
+  try {
+    const { id } = req.params;
+
+    // Find the specific unlock by ID
+    const unlock = await SecretDropUnlock.findById(id).populate({
+      path: 'capsuleId',
+      select:
+        'message location hint creatorId unlockConditions visibility metadata',
+    });
+
+    // Check if unlock exists and belongs to the requesting user
+    if (!unlock || unlock.userId.toString() !== req.user._id.toString()) {
+      return res.status(404).json({
+        success: false,
+        message: 'Unlock record not found',
+      });
+    }
+
+    // Check if related capsule exists
+    if (!unlock.capsuleId) {
+      return res.status(200).json({
+        success: true,
+        data: {
+          id: unlock._id,
+          unlockTime: unlock.unlockTime,
+          capsuleDeleted: true,
+        },
+      });
+    }
+
+    // Format the result
+    const formattedUnlock = {
+      id: unlock._id,
+      unlockTime: unlock.unlockTime,
+      distanceAtUnlock: unlock.distanceAtUnlock,
+      userLocation: unlock.userLocation,
+      capsule: {
+        id: unlock.capsuleId._id,
+        message: unlock.capsuleId.message,
+        location: unlock.capsuleId.location,
+        hint: unlock.capsuleId.hint,
+        creatorId: unlock.capsuleId.creatorId,
+        unlockConditions: unlock.capsuleId.unlockConditions,
+        visibility: unlock.capsuleId.visibility,
+        metadata: unlock.capsuleId.metadata,
+      },
+      reply: unlock.reply,
+      // Calculate if user can still reply
+      canReply: unlock.canReply,
+      streakDay: unlock.streakDay,
+    };
+
+    return res.status(200).json({
+      success: true,
+      data: formattedUnlock,
+    });
+  } catch (error) {
+    console.error('Error fetching unlock details:', error);
+    return res.status(500).json({
+      success: false,
+      message: 'An error occurred while fetching unlock details',
+      error: process.env.NODE_ENV === 'development' ? error.message : undefined,
+    });
+  }
+};

--- a/src/models/secretDrop/secretDropUnlock.ts
+++ b/src/models/secretDrop/secretDropUnlock.ts
@@ -1,0 +1,111 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const pointSchema = new mongoose.Schema({
+  type: {
+    type: String,
+    enum: ['Point'],
+    required: true,
+    default: 'Point',
+  },
+  coordinates: {
+    type: [Number], // [longitude, latitude]
+    required: true,
+  },
+});
+
+const secretDropUnlockSchema = new Schema(
+  {
+    userId: {
+      type: Schema.Types.ObjectId,
+      ref: 'User',
+      required: true,
+      index: true,
+    },
+    capsuleId: {
+      type: Schema.Types.ObjectId,
+      ref: 'CapsuleLabCapsule',
+      required: true,
+      index: true,
+    },
+    unlockTime: {
+      type: Date,
+      required: true,
+      default: Date.now,
+    },
+    userLocation: {
+      type: pointSchema,
+      required: true,
+    },
+    distanceAtUnlock: {
+      type: Number,
+      required: true,
+    },
+    reply: {
+      content: {
+        type: String,
+        trim: true,
+        maxlength: 500,
+      },
+      createdAt: {
+        type: Date,
+      },
+      updatedAt: {
+        type: Date,
+      },
+    },
+    streakDay: {
+      type: Number,
+      default: 0,
+    },
+    metadata: {
+      type: Schema.Types.Mixed,
+      default: {},
+    },
+  },
+  {
+    timestamps: true,
+    toJSON: { virtuals: true },
+    toObject: { virtuals: true },
+  }
+);
+
+secretDropUnlockSchema.index({ userId: 1, capsuleId: 1 }, { unique: true });
+
+secretDropUnlockSchema.virtual('canReply').get(function () {
+  if (this.reply?.content) return false;
+
+  const now = new Date();
+  const unlockTime = new Date(this.unlockTime);
+  const timeDiff = now - unlockTime;
+
+  return timeDiff < 5 * 60 * 1000;
+});
+
+secretDropUnlockSchema.methods.addReply = async function (content) {
+  if (!this.canReply) {
+    throw new Error('Reply window has expired');
+  }
+
+  const now = new Date();
+
+  if (!this.reply?.content) {
+    this.reply = {
+      content,
+      createdAt: now,
+      updatedAt: now,
+    };
+  } else {
+    this.reply.content = content;
+    this.reply.updatedAt = now;
+  }
+
+  return this.save();
+};
+
+const SecretDropUnlock = mongoose.model(
+  'SecretDropUnlock',
+  secretDropUnlockSchema
+);
+
+module.exports = SecretDropUnlock;

--- a/src/models/secretDropCapsule.ts
+++ b/src/models/secretDropCapsule.ts
@@ -1,82 +1,155 @@
-import mongoose, { Schema, Document } from 'mongoose';
+import mongoose from 'mongoose';
+import { CapsuleLabCapsule, VALID_CAPSULE_TYPES, capsuleLabSchema } from './baseCapsule';
+import Joi from 'joi';
 
-// Types for unlock conditions and visibility
-const TimeWindowSchema = new Schema({
-  start: { type: Date },
-  end: { type: Date },
-}, { _id: false });
-
-const UnlockConditionsSchema = new Schema({
-  timeWindow: { type: TimeWindowSchema },
-}, { _id: false });
-
-const VisibilitySchema = new Schema({
-  public: { type: Boolean, default: true },
-}, { _id: false });
-
-// Capsule Document interface
-export interface SecretDropCapsuleDocument extends Document {
-  creatorId: string;
-  title: string;
-  message: string;
-  location: {
-    type: 'Point';
-    coordinates: [number, number];
-  };
-  isActive: boolean;
-  visibility: {
-    public: boolean;
-  };
-  unlockConditions?: {
-    timeWindow?: {
-      start?: Date;
-      end?: Date;
-    };
-  };
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-// Main Capsule Schema
-const SecretDropCapsuleSchema = new Schema<SecretDropCapsuleDocument>(
-  {
-    creatorId: { type: String, required: true },
-    title: { type: String, required: true },
-    message: { type: String, required: true },
-
-    location: {
-      type: {
-        type: String,
-        enum: ['Point'],
-        required: true,
+// Define the GeoJSON Point schema for location
+const pointSchema = new mongoose.Schema({
+  type: {
+    type: String,
+    enum: ['Point'],
+    required: true,
+    default: 'Point',
+  },
+  coordinates: {
+    type: [Number], // [longitude, latitude]
+    required: true,
+    validate: {
+      validator: function (coords) {
+        return (
+          coords.length === 2 &&
+          coords[0] >= -180 &&
+          coords[0] <= 180 && // longitude
+          coords[1] >= -90 &&
+          coords[1] <= 90
+        ); // latitude
       },
-      coordinates: {
-        type: [Number], // [longitude, latitude]
-        required: true,
-      },
-    },
-
-    isActive: { type: Boolean, default: true },
-
-    visibility: {
-      type: VisibilitySchema,
-      default: { public: true },
-    },
-
-    unlockConditions: {
-      type: UnlockConditionsSchema,
-      default: {},
+      message:
+        'Invalid coordinates. Longitude must be between -180 and 180, and latitude between -90 and 90.',
     },
   },
-  {
-    timestamps: true,
+});
+
+// Schema for SecretDrop-specific fields
+const secretDropSchema = new mongoose.Schema({
+  message: {
+    type: String,
+    required: true,
+    trim: true,
+    minlength: 1,
+    maxlength: 5000,
+  },
+  location: {
+    type: pointSchema,
+    required: true,
+    index: '2dsphere', // Create geospatial index for location queries
+  },
+  unlockConditions: {
+    distance: {
+      type: Number,
+      required: true,
+      min: 5, // Minimum 5 meters
+      max: 1000, // Maximum 1km
+    },
+    timeWindow: {
+      start: {
+        type: Date,
+      },
+      end: {
+        type: Date,
+        validate: {
+          validator: function (endDate) {
+            // If both start and end are provided, ensure end is after start
+            const startDate = this.unlockConditions?.timeWindow?.start;
+            return !startDate || !endDate || endDate > startDate;
+          },
+          message: 'End time must be after start time',
+        },
+      },
+    },
+  },
+  hint: {
+    type: String,
+    trim: true,
+    maxlength: 200,
+  },
+  unlockCount: {
+    type: Number,
+    default: 0,
+  },
+  // Additional SecretDrop-specific fields can be added here
+});
+
+// Create the discriminator model
+const SecretDropCapsule = CapsuleLabCapsule.discriminator(
+  VALID_CAPSULE_TYPES.SECRET_DROP,
+  secretDropSchema
+);
+
+// Joi validation schema for API input validation
+const secretDropValidationSchema = Joi.object({
+  message: Joi.string().trim().min(1).max(5000).required(),
+  location: Joi.object({
+    coordinates: Joi.array()
+      .ordered(
+        Joi.number().min(-180).max(180).required(), // longitude
+        Joi.number().min(-90).max(90).required() // latitude
+      )
+      .length(2)
+      .required(),
+  }).required(),
+  unlockConditions: Joi.object({
+    distance: Joi.number().min(5).max(1000).required(),
+    timeWindow: Joi.object({
+      start: Joi.date().iso(),
+      end: Joi.date().iso().greater(Joi.ref('start')),
+    }),
+  }).required(),
+  visibility: Joi.object({
+    public: Joi.boolean(),
+    ttlHours: Joi.number().integer().min(1).max(8760),
+    maxUnlocks: Joi.number().integer().min(1),
+  }),
+  hint: Joi.string().trim().max(200),
+});
+
+// Helper function to validate SecretDrop payload
+function validateSecretDropPayload(payload) {
+  return secretDropValidationSchema.validate(payload, { abortEarly: false });
+}
+
+// Helper function to format the capsule data for API responses
+function formatCapsuleForResponse(capsule, includeFullDetails = true) {
+  const response = {
+    id: capsule._id,
+    type: capsule.type,
+    location: capsule.location,
+    createdAt: capsule.createdAt,
+    unlockConditions: {
+      distance: capsule.unlockConditions.distance,
+    },
+    hint: capsule.hint,
+    unlockCount: capsule.unlockCount,
+  };
+
+  // Add time window if it exists
+  if (capsule.unlockConditions.timeWindow?.start) {
+    response.unlockConditions.timeWindow = {
+      start: capsule.unlockConditions.timeWindow.start,
+      end: capsule.unlockConditions.timeWindow.end,
+    };
   }
-);
 
-// 2dsphere index for geospatial queries
-SecretDropCapsuleSchema.index({ location: '2dsphere' });
+  // Include message and other details only if full details are requested
+  if (includeFullDetails) {
+    response.message = capsule.message;
+    response.visibility = capsule.visibility;
+  }
 
-export const SecretDropCapsuleModel = mongoose.model<SecretDropCapsuleDocument>(
-  'SecretDropCapsule',
-  SecretDropCapsuleSchema
-);
+  return response;
+}
+
+module.exports = {
+  SecretDropCapsule,
+  validateSecretDropPayload,
+  formatCapsuleForResponse,
+};


### PR DESCRIPTION
#### Overview  
This PR adds the `SecretDropUnlock` schema to track when users unlock SecretDrop capsules, and implements the `/secretDrop/unlocked` endpoint to retrieve a user's unlock history.

#### ✅ What's Included  
- Created `SecretDropUnlock` Mongoose schema with fields:
  - `userId`
  - `capsuleId`
  - `unlockTime`
  - `userLocation`
  - Optional `response`
- Implemented logic to **prevent double-unlocking** by the same user for the same capsule.
- Added `GET /secretDrop/unlocked` endpoint to fetch a user’s unlock history.

#### 🧪 Acceptance Criteria  
- Unlocks are logged accurately with all required fields.  
- Users cannot unlock the same SecretDrop more than once.  
- `GET /secretDrop/unlocked` returns all unlock entries tied to the authenticated user.  
- Appropriate error is returned if duplicate unlock is attempted.

#### ⚙️ Technical Details  
- Enforced uniqueness constraint on `userId` + `capsuleId` combination.  
- Endpoint supports proper authentication and authorization.  
- Location stored as a valid GeoJSON object if applicable.

closes #136 